### PR TITLE
Use non-default `wandb` directory and improve `Tracker` print strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,9 +146,10 @@ wandb
 VSEQ.env
 
 # data files
-.wav
-.flac
-.mp3
+*.wav
+*.flac
+*.mp3
+*.png
 
 # miscellaneous
 miscellaneous

--- a/README.md
+++ b/README.md
@@ -37,6 +37,23 @@ This repo uses [Python type-hints](https://docs.python.org/3/library/typing.html
 It also extends this with the [`torchtyping`](https://github.com/patrick-kidger/torchtyping) package which allows defining the shape, data type, layout and names of axis of `torch.Tensors` by using a new `TensorType[...]` type.
 
 
+## wandb
+
+We track experiments using wandb.
+
+### Enable/Disable
+
+- `wandb online`, `WANDB_MODE=online` or `wandb.init(mode="online")` - runs in online mode, the default
+- `wandb offline`, `WANDB_MODE=offline` or `wandb.init(mode="offline")` - runs in offline mode, writes all data to disk for later syncing to a server
+- `wandb disabled`, `WANDB_MODE=disabled` or `wandb.init(mode="disabled")` - makes all calls to wandb api's noop's, while maintaining core functionality such as wandb.config and wandb.summary in case you have logic that reads from these dicts.
+- `wandb enabled`, `WANDB_MODE=` or `wandb.init(mode="enabled")`- sets the mode to back online
+
+### Clean
+
+In the `wandb` directory `/some/path/wandb` run:
+- `wandb sync --clean` to clean out all previously synced runs.
+- `wandb sync --clean-old-hours INT` to clean out all runs older than `INT` hours.
+
 ### wandb sweeps
 
 See `experiments/sweep_test.yaml`
@@ -44,14 +61,6 @@ See `experiments/sweep_test.yaml`
 > `wandb sweep experiments/sweeps/sweep_test.yaml`
 
 > `wandb agent <sweep-id>`
-
-## Enable/Disable
-
-- `wandb online`, `WANDB_MODE=online` or `wandb.init(mode="online")` - runs in online mode, the default
-- `wandb offline`, `WANDB_MODE=offline` or `wandb.init(mode="offline")` - runs in offline mode, writes all data to disk for later syncing to a server
-- `wandb disabled`, `WANDB_MODE=disabled` or `wandb.init(mode="disabled")` - makes all calls to wandb api's noop's, while maintaining core functionality such as wandb.config and wandb.summary in case you have logic that reads from these dicts.
-- `wandb enabled`, `WANDB_MODE=` or `wandb.init(mode="enabled")`- sets the mode to back online
-
 
 ## Implementation suggestions
 - [ ] Method or class to define and build `Dataloader`s with proper defaults e.g. `pin_memory == True`.

--- a/experiments/experiment_bowman.py
+++ b/experiments/experiment_bowman.py
@@ -1,6 +1,5 @@
 import argparse
 import logging
-from vseq.data.loaders import TextLoader
 
 import torch
 import wandb
@@ -17,6 +16,7 @@ import vseq.utils.device
 from vseq.data import BaseDataset
 from vseq.data.batchers import TextBatcher
 from vseq.data.datapaths import PENN_TREEBANK_TEST, PENN_TREEBANK_TRAIN, PENN_TREEBANK_VALID
+from vseq.data.loaders import TextLoader
 from vseq.data.tokens import DELIMITER_TOKEN
 from vseq.data.tokenizers import word_tokenizer
 from vseq.data.token_map import TokenMap

--- a/experiments/experiment_lstmlm.py
+++ b/experiments/experiment_lstmlm.py
@@ -1,5 +1,4 @@
 import argparse
-import logging
 import json
 
 import torch
@@ -10,7 +9,6 @@ from torch.utils.data import DataLoader
 
 import vseq
 import vseq.data
-from vseq.data import tokenizers
 import vseq.models
 import vseq.utils
 import vseq.utils.device

--- a/vseq/__init__.py
+++ b/vseq/__init__.py
@@ -1,0 +1,1 @@
+import vseq.settings

--- a/vseq/evaluation/metrics.py
+++ b/vseq/evaluation/metrics.py
@@ -10,7 +10,7 @@ from vseq.utils.operations import detach
 
 class Metric:
     base_tags = set()
-    _str_value_fmt = "<10.3"
+    _str_value_fmt = "<.3"
 
     def __init__(self, name: str, tags: set):
         self.name = name
@@ -49,7 +49,7 @@ def max_value(metrics: List[Metric]):
 
 
 class AccuracyMetric(Metric):
-    _str_value_fmt = "<10.3"
+    _str_value_fmt = "6.4"  # 6.4321
     get_best = max_value
 
     def __init__(
@@ -76,7 +76,7 @@ class AccuracyMetric(Metric):
 
 
 class RunningMeanMetric(Metric):
-    _str_value_fmt = "<10.3"
+    _str_value_fmt = "<.3"
 
     def __init__(
         self,
@@ -177,7 +177,7 @@ class KLMetric(RunningMeanMetric):
 class BitsPerDimMetric(RunningMeanMetric):
     base_tags = set()
     get_best = min_value
-    _str_value_fmt = "<5.3"
+    _str_value_fmt = "<5.3"  # 5.321
 
     def __init__(
         self,
@@ -192,15 +192,11 @@ class BitsPerDimMetric(RunningMeanMetric):
 
 
 class PerplexityMetric(BitsPerDimMetric):
-    """Perplexity computed as $2^{-\frac{1}{N} \sum_{i=1}^N \log p_\theta(x_i)}$
-
-    Args:
-        RunningMeanMetric ([type]): [description]
-    """
+    """Perplexity computed as $2^{-\frac{1}{N} \sum_{i=1}^N \log p_\theta(x_i)}$"""
 
     base_tags = set()
     get_best = min_value
-    _str_value_fmt = "<8.3"
+    _str_value_fmt = "<8.3"  # 8765.321
 
     def __init__(
         self,

--- a/vseq/settings.py
+++ b/vseq/settings.py
@@ -3,9 +3,12 @@
 import os
 import logging
 
+from typing import Any
+
 
 ROOT_PATH = __file__.replace("/vseq/settings.py", "")
 ENV_FILE = os.path.join(ROOT_PATH, "VSEQ.env")
+
 
 def read_env_file():
     if not os.path.exists(ENV_FILE):
@@ -15,34 +18,62 @@ def read_env_file():
         env_text = envfile_buffer.read()
     return dict([line.split("=") for line in env_text.splitlines()])
 
+
 ENV = read_env_file()
 
-def set_vseq_envvar(envvar):
-    envvar_value = input(f"\nRequired environment variable {envvar} not set.\n\nPlease specify:\n> ")
+
+def write_vseq_envvar(envvar: str, envvar_value: str):
+    """Write an envvar to the ENV_FILE"""
     with open(ENV_FILE, "a") as envfile_buffer:
         envfile_buffer.write(f"{envvar}={envvar_value}\n")
+
+
+def require_vseq_envvar(envvar):
+    """Request user for value of a required envvar and write it to the ENV_FILE"""
+    envvar_value = input(f"\nRequired environment variable {envvar} not set.\n\nPlease specify:\n> ")
+    write_vseq_envvar(envvar, envvar_value)
     return envvar_value
 
-def get_vseq_envvar(envvar, default=None):
-    
+
+def get_vseq_envvar(envvar, default: Any = None, reflect: bool = False):
+    """Retrieve the value of an envvar.
+
+    In prioritized order, returns the value found in `os.environ`, `ENV_FILE`, `default`.
+
+    If `default` is `None`, requires the envvar to be set and requests it from the user at runtime.
+    If `reflect` is `True`, reflects the retrieved value into `os.environ`.
+    """
     if envvar in os.environ:
         return os.getenv(envvar)
-    if envvar in ENV:
-        return ENV[envvar]
-    if default is None:
-        return set_vseq_envvar(envvar)
-    return default
 
-# Logging
+    if envvar in ENV:
+        value = ENV[envvar]
+    elif default is None:
+        value = require_vseq_envvar(envvar)
+    else:
+        value = default
+
+    if reflect:
+        os.environ[envvar] = value
+
+    return value
+
+
+# logging
 LOG_FORMAT = "%(asctime)-15s - %(module)-20s - %(levelname)-7s | %(message)s"
 LOG_LEVEL = get_vseq_envvar("VSEQ_LOG_LEVEL", "INFO")
 logging.basicConfig(format=LOG_FORMAT, level=logging.getLevelName(LOG_LEVEL))
 
+# data directories
 DATA_ROOT_DIRECTORY = get_vseq_envvar("VSEQ_DATA_ROOT_DIRECTORY", default=None)
 DATA_DIRECTORY = os.path.join(DATA_ROOT_DIRECTORY, "data")
 SOURCE_DIRECTORY = os.path.join(DATA_ROOT_DIRECTORY, "source")
 VOCAB_DIRECTORY = os.path.join(DATA_ROOT_DIRECTORY, "vocabularies")
 
+# set wandb directory to inside data directory
+DEFAULT_WANDB_DIR = os.path.join(DATA_ROOT_DIRECTORY, "wandb")
+WANDB_DIR = get_vseq_envvar("WANDB_DIR", default=DEFAULT_WANDB_DIR, reflect=True)
 
-for path in [DATA_DIRECTORY, SOURCE_DIRECTORY, VOCAB_DIRECTORY]:
+# make directories
+for path in [DATA_DIRECTORY, SOURCE_DIRECTORY, VOCAB_DIRECTORY, WANDB_DIR]:
     os.makedirs(path, exist_ok=True)

--- a/vseq/settings.py
+++ b/vseq/settings.py
@@ -71,8 +71,7 @@ SOURCE_DIRECTORY = os.path.join(DATA_ROOT_DIRECTORY, "source")
 VOCAB_DIRECTORY = os.path.join(DATA_ROOT_DIRECTORY, "vocabularies")
 
 # set wandb directory to inside data directory
-DEFAULT_WANDB_DIR = os.path.join(DATA_ROOT_DIRECTORY, "wandb")
-WANDB_DIR = get_vseq_envvar("WANDB_DIR", default=DEFAULT_WANDB_DIR, reflect=True)
+WANDB_DIR = get_vseq_envvar("WANDB_DIR", default=DATA_ROOT_DIRECTORY, reflect=True)
 
 # make directories
 for path in [DATA_DIRECTORY, SOURCE_DIRECTORY, VOCAB_DIRECTORY, WANDB_DIR]:


### PR DESCRIPTION
- Changes the default `wandb` directory to `<DATA_ROOT_DIRECTORY>/wandb` to reduce storage issues on `/home` on Linux systems.
- Make the `Tracker` dynamically compute the length of the formatting (for `rich`) to print empty/dashed lines of correct length.